### PR TITLE
Renamed all bottle to airdrop

### DIFF
--- a/internal/enum.h
+++ b/internal/enum.h
@@ -30,16 +30,15 @@ enum drop_mode {
 };
 typedef enum drop_mode drop_mode_t;
 
-enum bottle {
+enum airdrop {
     UDP2_A = 1,
     UDP2_B = 2,
     UDP2_C = 3,
     UDP2_D = 4, 
-    UDP2_E = 5,
     UDP2_ALL = 7
     // note max 3 bits for this value
 };
-typedef enum bottle bottle_t;
+typedef enum airdrop airdrop_t;
 
 enum payload_state {
     OBC_NULL = 0, // Sent by the OBC, does not map to any state on the payload

--- a/internal/helper.c
+++ b/internal/helper.c
@@ -11,25 +11,25 @@ void parseID(uint8_t id, uint8_t* payloadID, uint8_t* state) {
     *state  = (id & 0b00000111);
 }
 
-uint8_t makeID(bottle_t payloadID, payload_state_t state) {
+uint8_t makeID(airdrop_t payloadID, payload_state_t state) {
     return (((uint8_t)(payloadID) << 3) | (uint8_t)(state));
 }
 
-packet_t makeDropNowPacket(bottle_t bottle) {
+packet_t makeDropNowPacket(airdrop_t airdrop) {
     packet_t p;
     p.header = (uint8_t) DROP_NOW;
-    p.id     = makeID(bottle, OBC_NULL);
+    p.id     = makeID(airdrop, OBC_NULL);
     return p;
 }
 
-packet_t makeResetPacket(bottle_t bottle) {
+packet_t makeResetPacket(airdrop_t airdrop) {
     packet_t p;
     p.header = (uint8_t) RESET;
-    p.id     = makeID(bottle, OBC_NULL);
+    p.id     = makeID(airdrop, OBC_NULL);
     return p;
 }
 
-packet_t makeModePacket(header_t header, bottle_t payloadID,
+packet_t makeModePacket(header_t header, airdrop_t payloadID,
     payload_state_t state, drop_mode_t mode)
 {
     assert(header == ACK_MODE || header == SET_MODE);
@@ -43,7 +43,7 @@ packet_t makeModePacket(header_t header, bottle_t payloadID,
     return (p);
 }
 
-packet_t makeHeartbeatPacket(bottle_t payloadID, payload_state_t state,
+packet_t makeHeartbeatPacket(airdrop_t payloadID, payload_state_t state,
     float payload_lat, float payload_lng, uint16_t volts, uint16_t altitude_m)
 {
     packet_t p;
@@ -57,7 +57,7 @@ packet_t makeHeartbeatPacket(bottle_t payloadID, payload_state_t state,
     return p;
 }
 
-packet_t makeLatLngPacket(header_t header, bottle_t payloadID, payload_state_t state,
+packet_t makeLatLngPacket(header_t header, airdrop_t payloadID, payload_state_t state,
     float drop_lat, float drop_lng, uint32_t curr_alt_m)
 {
     assert(header == SEND_LATLNG || header == ACK_LATLNG);
@@ -72,7 +72,7 @@ packet_t makeLatLngPacket(header_t header, bottle_t payloadID, payload_state_t s
     return p;
 }
 
-packet_t makeArmPacket(header_t header, bottle_t payloadID, payload_state_t state, uint32_t curr_alt_m) {
+packet_t makeArmPacket(header_t header, airdrop_t payloadID, payload_state_t state, uint32_t curr_alt_m) {
     assert(header == ACK_ARM || header == ACK_DISARM ||
         header == ARM || header == DISARM);
 

--- a/internal/helper.h
+++ b/internal/helper.h
@@ -25,29 +25,29 @@ void parseID(uint8_t id, uint8_t* payloadID, uint8_t* state);
     manipulation to fit them in the same byte, according to the schema
     specified above.
 */
-uint8_t makeID(bottle_t payloadID, payload_state_t state);
+uint8_t makeID(airdrop_t payloadID, payload_state_t state);
 
 /*
     Makes a packet to tell a payload to drop all now
 */
-packet_t makeDropNowPacket(bottle_t bottle);
+packet_t makeDropNowPacket(airdrop_t airdrop);
 
 /*
     Makes a reset packet to send to a specific bottle.
 
     Used by the OBC to create a RESET packet
 */
-packet_t makeResetPacket(bottle_t bottle);
+packet_t makeResetPacket(airdrop_t airdrop);
 
-packet_t makeModePacket(header_t header, bottle_t payloadID,
+packet_t makeModePacket(header_t header, airdrop_t payloadID,
     payload_state_t state, drop_mode_t mode);
 
-packet_t makeHeartbeatPacket(bottle_t payloadID, payload_state_t state,
+packet_t makeHeartbeatPacket(airdrop_t payloadID, payload_state_t state,
     float payload_lat, float payload_lng, uint16_t volts, uint16_t altitude_m);
 
-packet_t makeLatLngPacket(header_t header, bottle_t payloadID, payload_state_t state,
+packet_t makeLatLngPacket(header_t header, airdrop_t payloadID, payload_state_t state,
     float drop_lat, float drop_lng, uint32_t curr_alt_m);
 
-packet_t makeArmPacket(header_t header, bottle_t payloadID, payload_state_t state, uint32_t curr_alt_m);
+packet_t makeArmPacket(header_t header, airdrop_t payloadID, payload_state_t state, uint32_t curr_alt_m);
 
 #endif  // HELPER_H_


### PR DESCRIPTION
Renamed all bottle instances to airdrop for the new obc to compile

Should be merged concurrently with tritonuas/obcpp#238 tritonuas/gcs#150 tritonuas/protos#10 (things will break if we don't)